### PR TITLE
Update the table data when it’s modified in props

### DIFF
--- a/src/TableBody.js
+++ b/src/TableBody.js
@@ -24,6 +24,14 @@ class TableBody extends Component {
     };
   }
 
+  componentWillReceiveProps(props) {
+    this.setState(update(this.state, {
+      data: {
+        $set: props.data
+      }
+    }));
+  }
+
   render() {
     const { cellEdit, beforeShowError, x, y, keyBoardNav } = this.props;
     const tableClasses = classSet('table', {


### PR DESCRIPTION
We switched the TableBody to use its local state so that it could internally update the row order when dragging rows around. Pagination injects a new data set into the TableBody via props, but we were reading only from state, which was not being updated. This just updates the local state based on passed props to get around this.

I don’t believe it’s correct to use the TableBody’s local state, and instead we should bubble drag and drop operations up to the main state container (the BootstrapTable) instead similarly to how the sort controls on the table header work, but this is a short-term patch that at least buys us time to refactor to that effect.

**Note**: When we merge this, we must immediately merge an update to yarn.lock in the consuming application to avoid blocking the deployment pipeline.